### PR TITLE
WP-11048 Use iter_lines instead of raw_stream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='1.3.12',
+      version='1.3.13',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -27,7 +27,7 @@ def do_discover(config):
 
 
 def stream_is_selected(mdata):
-    return mdata.get((), {}).get('selected', False)
+    return mdata.get((), {}).get('selected', True)
 
 
 def do_sync(config, catalog, state):
@@ -100,8 +100,8 @@ def main():
                 break
         except BaseException as err:
             LOGGER.error(err)
-        
-        # If not external source, it is from importing csv (replacement for tap-csv) 
+
+        # If not external source, it is from importing csv (replacement for tap-csv)
         dialect.detect_tables_dialect(config)
 
     if args.discover:

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -27,7 +27,7 @@ def do_discover(config):
 
 
 def stream_is_selected(mdata):
-    return mdata.get((), {}).get('selected', True)
+    return mdata.get((), {}).get('selected', False)
 
 
 def do_sync(config, catalog, state):

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -263,8 +263,6 @@ def sample_file(table_spec, s3_path, file_handle, sample_rate, extension):
         return []
     if extension in ["csv", "txt"]:
         # If file object read from s3 bucket file else use extracted file object from zip or gz
-        # file_handle = file_handle._raw_stream if hasattr(
-        #     file_handle, "_raw_stream") else file_handle  # pylint:disable=protected-access
         iterator = csv_iterator.get_row_iterator(file_handle, table_spec)
         csv_records = []
         if iterator:

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -263,8 +263,8 @@ def sample_file(table_spec, s3_path, file_handle, sample_rate, extension):
         return []
     if extension in ["csv", "txt"]:
         # If file object read from s3 bucket file else use extracted file object from zip or gz
-        file_handle = file_handle._raw_stream if hasattr(
-            file_handle, "_raw_stream") else file_handle  # pylint:disable=protected-access
+        # file_handle = file_handle._raw_stream if hasattr(
+        #     file_handle, "_raw_stream") else file_handle  # pylint:disable=protected-access
         iterator = csv_iterator.get_row_iterator(file_handle, table_spec)
         csv_records = []
         if iterator:

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -102,7 +102,7 @@ def handle_file(config, s3_path, table_spec, stream, extension, file_handler=Non
 
         # If file is extracted from zip or gz use file object else get file object from s3 bucket
         file_handle = file_handler if file_handler else s3.get_file_handle(
-            config, s3_path)._raw_stream  # pylint:disable=protected-access
+            config, s3_path)  # pylint:disable=protected-access
         return sync_csv_file(config, file_handle, s3_path, table_spec, stream)
 
     if extension == "jsonl":


### PR DESCRIPTION
https://varicent.atlassian.net/browse/WP-11048

From botocore documentation:
`iter_lines(chunk_size=1024, keepends=False): Return an iterator to yield lines from the raw stream.`

No need to check for raw stream since iter_lines will get it from the raw stream. 

The issue with Speed Dating Data.csv was that the new-line character was used with `\r` which was not detected in our tap-s3-csv. iter_lines seem to be able to pick up different types of new-line character (`\r, \n or \r\n`) which is what we need