### PR TITLE
WP-12538 Excel Import fails when column name is longer than 150 characters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-s3-csv"
-version = "1.4.2"
+version = "1.4.3"
 description = "Singer.io tap for extracting CSV files from S3"
 authors = ["Stitch"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]


### PR DESCRIPTION
WP-12538 Excel Import fails when column name is longer than 150 characters
https://varicent.atlassian.net/browse/WP-12538

notes:
- added fix to truncate column names to 150 in length
- no duplicate --> use the truncated col as is
- duplicate --> truncate a bit more and add _{id} that would make the column name distinct