### PR TITLE
WP-12538 Excel Import fails when column name is longer than 150 characters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-s3-csv"
-version = "1.4.3"
+version = "1.4.4"
 description = "Singer.io tap for extracting CSV files from S3"
 authors = ["Stitch"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]

--- a/tap_s3_csv/csv_iterator.py
+++ b/tap_s3_csv/csv_iterator.py
@@ -73,7 +73,7 @@ def truncate_headers(column_names):
     new_column_names = []
 
     for cname in column_names:
-        if len(cname) > MAX_COL_LENGTH:
+        if cname is not None and len(cname) > MAX_COL_LENGTH:
             cname = cname[:MAX_COL_LENGTH]
             if cname not in truncated_cols_map:
                 truncated_cols_map[cname] = 0


### PR DESCRIPTION
added fix for checking length on none type
