### PR TITLE
WP-14093 Import file with duplicate headers is failing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-s3-csv"
-version = "1.4.12"
+version = "1.4.13"
 description = "Singer.io tap for extracting CSV files from S3"
 authors = ["Stitch"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]

--- a/tap_s3_csv/csv_iterator.py
+++ b/tap_s3_csv/csv_iterator.py
@@ -60,7 +60,7 @@ def truncate_headers(fieldnames):
 
     # update fieldname_to_index to include first occurring index of column name for column names that don't need truncation
     for index, fieldname in enumerate(fieldnames):
-        if pd.isna(fieldname) or fieldname == '' or len(fieldname) > MAX_COL_LENGTH:
+        if fieldname is None or fieldname == '' or len(fieldname) > MAX_COL_LENGTH:
             continue
 
         fieldname_lowercase = fieldname.casefold()
@@ -70,7 +70,7 @@ def truncate_headers(fieldnames):
 
     # update fieldname_to_index map to include first occurring index of column name for column names that need truncation
     for index, fieldname in enumerate(fieldnames):
-        if pd.isna(fieldname) or fieldname == '' or len(fieldname) <= MAX_COL_LENGTH:
+        if fieldname is None or fieldname == '' or len(fieldname) <= MAX_COL_LENGTH:
             continue
 
         fieldname = fieldname[:MAX_COL_LENGTH]
@@ -87,7 +87,7 @@ def truncate_headers(fieldnames):
     #   if index is the first occurring index for given fieldname, use it
     #   else, resolve duplicate by adding "_{id}"
     for index, fieldname in enumerate(fieldnames):
-        if pd.isna(fieldname) or fieldname == '':
+        if fieldname is None or fieldname == '':
             continue
 
         if len(fieldname) > MAX_COL_LENGTH:


### PR DESCRIPTION
WP-14093 Import file with duplicate headers is failing
https://varicent.atlassian.net/browse/WP-14093

notes:
- trailing white space in column header considers 'col1' and 'col1 '  as non duplicate -> fix to trim
- address edge case for truncating and resolving duplicate column names