### PR TITLE
WP-14838 data pre-process configuration: header/footer rows and column header [API]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-s3-csv"
-version = "1.4.14"
+version = "1.4.15"
 description = "Singer.io tap for extracting CSV files from S3"
 authors = ["Stitch"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]

--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -9,5 +9,8 @@ CONFIG_CONTRACT = Schema([{
     Optional('delimiter'): str,
     Optional('escape_char'): str,
     Optional('recursive_search'): bool,
-    Optional('quotechar'): str
+    Optional('quotechar'): str,
+    Optional('skip_header_row'): int,
+    Optional('skip_footer_row'): int,
+    Optional('has_header'): bool
 }])

--- a/tap_s3_csv/csv_iterator.py
+++ b/tap_s3_csv/csv_iterator.py
@@ -4,7 +4,7 @@ import csv
 MAX_COL_LENGTH = 150
 
 
-def get_row_iterator(iterable, fieldnames, options=None):
+def get_row_iterator(iterable, options=None, fieldnames=None):
     options = options or {}
     file_stream = codecs.iterdecode(
         iterable.iter_lines(), encoding=options.get('encoding', 'utf-8'), errors='replace')
@@ -129,4 +129,3 @@ def handle_empty_fieldnames(fieldnames, options):
         final_fieldnames.append(fieldname)
 
     return final_fieldnames
-

--- a/tap_s3_csv/csv_iterator.py
+++ b/tap_s3_csv/csv_iterator.py
@@ -4,17 +4,15 @@ import csv
 MAX_COL_LENGTH = 150
 
 
-def get_row_iterator(iterable, options=None):
+def get_row_iterator(iterable, fieldnames, options=None):
     options = options or {}
     file_stream = codecs.iterdecode(
         iterable.iter_lines(), encoding=options.get('encoding', 'utf-8'), errors='replace')
 
-    field_names = None
-
     # Replace any NULL bytes in the line given to the DictReader
     reader = csv.DictReader(
         (line.replace('\0', '') for line in file_stream),
-        fieldnames=field_names,
+        fieldnames=fieldnames,
         delimiter=options.get('delimiter', ','),
         escapechar=options.get('escape_char', '\\'),
         quotechar=options.get('quotechar', '"'))
@@ -27,12 +25,6 @@ def get_row_iterator(iterable, options=None):
 
     reader.fieldnames = handle_empty_fieldnames(
         reader.fieldnames, options)
-
-    # csv.DictReader skips empty rows, but we wish to keep empty rows for csv imports, so override __next__ method.
-    # Only modifying for imports from csv connector for now as imports from s3 connector might have reasons for skipping empty rows.
-    # Could look into using csv.reader instead for cleaner code if s3 connector could also keep empty rows.
-    if options.get('is_csv_connector_import', False):
-        csv.DictReader.__next__ = next_without_skip
 
     # We do not use key_properties and date_overrides in our config. If we use these later, will need to add code for checking over
     # whether fieldnames included in key_properties/date_overrides have been modified in handle_empty_fieldnames and handle appropriately.
@@ -138,24 +130,3 @@ def handle_empty_fieldnames(fieldnames, options):
 
     return final_fieldnames
 
-# csv.DictReader class skips empty rows when iterating over file stream.
-# method to use for overriding csv.DictReader.__next__ in case we wish to keep empty rows
-
-
-def next_without_skip(self):
-    if self.line_num == 0:
-        # Used only for its side effect.
-        self.fieldnames
-
-    row = next(self.reader)
-    self.line_num = self.reader.line_num
-
-    d = dict(zip(self.fieldnames, row))
-    lf = len(self.fieldnames)
-    lr = len(row)
-    if lf < lr:
-        d[self.restkey] = row[lf:]
-    elif lf > lr:
-        for key in self.fieldnames[lr:]:
-            d[key] = self.restval
-    return d

--- a/tap_s3_csv/dialect.py
+++ b/tap_s3_csv/dialect.py
@@ -4,7 +4,7 @@ import csv
 import cchardet as chardet
 import clevercsv
 
-from tap_s3_csv import s3
+from tap_s3_csv import s3, preprocess
 
 # We started using tap_s3_csv in 3.4 for both s3 and csv imports. Dialect detection
 # is only run for csv imports
@@ -68,7 +68,8 @@ def detect_dialect(config, s3_file, table):
 
     file_key = s3_file.get('key')
     file_handle = s3.get_file_handle(config, file_key)
-    file_iter = file_handle.iter_lines()
+    preprocess_file_handle = preprocess.PreprocessStream(file_handle, table)
+    file_iter = preprocess_file_handle.iter_lines()
     bytes_read = 0
     for i in range(MAX_LINES):
         try:

--- a/tap_s3_csv/dialect.py
+++ b/tap_s3_csv/dialect.py
@@ -68,6 +68,7 @@ def detect_dialect(config, s3_file, table):
 
     file_key = s3_file.get('key')
     file_handle = s3.get_file_handle(config, file_key)
+    # iterator that handles skip/ignore rows, need it for detecting delimiter, quotechars correctly
     preprocess_file_handle = preprocess.PreprocessStream(file_handle, table, False)
     file_iter = preprocess_file_handle.iter_lines()
     bytes_read = 0

--- a/tap_s3_csv/dialect.py
+++ b/tap_s3_csv/dialect.py
@@ -68,7 +68,7 @@ def detect_dialect(config, s3_file, table):
 
     file_key = s3_file.get('key')
     file_handle = s3.get_file_handle(config, file_key)
-    preprocess_file_handle = preprocess.PreprocessStream(file_handle, table)
+    preprocess_file_handle = preprocess.PreprocessStream(file_handle, table, False)
     file_iter = preprocess_file_handle.iter_lines()
     bytes_read = 0
     for i in range(MAX_LINES):

--- a/tap_s3_csv/preprocess.py
+++ b/tap_s3_csv/preprocess.py
@@ -37,16 +37,17 @@ class PreprocessStream():
             raise Exception(f'preprocess_err: No more data other than empty rows.')
         return first_row
     
+    # grabs first non empty row and process it as header row or first record row depending on has_header
     def _handle_first_row(self, has_header, encoding, delimiter):
         first_row = self._skip_empty_rows()
         first_row_list = first_row.decode(encoding).split(delimiter)
         
-        # first row is header row, don't need to store first_row as it is not a record
+        # first row is header row
         if has_header:
             self.header = first_row_list
             return
         
-        # first row is a record, need to store it so we can yield it in iter_lines
+        # first row is a record, generate headers and store first row so we can yield it in iter_lines
         self.first_row = first_row
         fieldnames = [f'col_{i}' for i in range(len(first_row_list))]
         self.header = fieldnames

--- a/tap_s3_csv/preprocess.py
+++ b/tap_s3_csv/preprocess.py
@@ -3,7 +3,6 @@ from queue import Queue
 # Wrapper class for file streams. Handles preprocessing (skipping header rows, footer rows, detecting headers)
 class PreprocessStream():
     def __init__(self, file_handle, table_spec, handle_first_row):
-        # self.file_iterator = iter(file_handle.iter_lines())
         self.file_iterator = file_handle.iter_lines()
         self.first_row = None
         self.queue = None
@@ -25,18 +24,17 @@ class PreprocessStream():
     def _skip_header_rows(self, skip_header_row):
         try:
             for _ in range(skip_header_row):
-                line = next(self.file_iterator)
+                next(self.file_iterator)
         except StopIteration:
-            #TODO improve err msg
-            raise Exception(f'No more data after skipping rows in header')
+            raise Exception(f'preprocess_err: No more data after skipping rows in header.')
 
     def _skip_empty_rows(self):
         try:
             first_row = next(self.file_iterator)
-            while first_row == b'':
+            while first_row == b'' or first_row == b'\n':
                 first_row = next(self.file_iterator)
         except StopIteration:
-            raise Exception(f'No more data other than empty rows')
+            raise Exception(f'preprocess_err: No more data other than empty rows.')
         return first_row
     
     def _handle_first_row(self, has_header, encoding, delimiter):

--- a/tap_s3_csv/preprocess.py
+++ b/tap_s3_csv/preprocess.py
@@ -26,7 +26,6 @@ class PreprocessStream():
         try:
             for _ in range(skip_header_row):
                 line = next(self.file_iterator)
-                print(line)
         except StopIteration:
             #TODO improve err msg
             raise Exception(f'No more data after skipping rows in header')

--- a/tap_s3_csv/preprocess.py
+++ b/tap_s3_csv/preprocess.py
@@ -1,0 +1,78 @@
+from queue import Queue
+
+# Wrapper class for file streams. Handles preprocessing (skipping header rows, footer rows, detecting headers)
+class PreprocessStream():
+    def __init__(self, file_handle, table_spec):
+        # self.file_iterator = iter(file_handle.iter_lines())
+        self.file_iterator = file_handle.iter_lines()
+        self.first_row = None
+        self.queue = None
+
+        skip_header_row = table_spec.get('skip_header_row', 0)
+        skip_footer_row = table_spec.get('skip_footer_row', 0)
+
+        if skip_header_row > 0:
+            self._skip_header_rows(skip_header_row)
+        if skip_footer_row > 0:
+            self.queue = Queue(maxsize = skip_footer_row)
+    
+    def get_headers(self, table_spec):
+        has_header = table_spec.get('has_header', True)
+        fieldnames = None
+
+        # if headers exist, let csv.DictReader grab the header. csv.DictReader automatically skips empty rows
+        # and uses first valid row as header
+        if has_header:
+            return fieldnames
+        
+        first_row = self._skip_empty_rows()
+        delimiter = table_spec.get('delimiter', ',')
+        encoding = table_spec.get('encoding', 'utf-8')
+
+        first_row_list = first_row.decode(encoding).split(delimiter)
+        fieldnames = [f'col_{i}' for i in range(len(first_row_list))]
+        
+        # has_header is false, so first row is record, not header. save it to yield later
+        self.first_row = first_row
+
+        return fieldnames
+
+    def move_to_first_row(self, has_header):
+        first_row = self._skip_empty_rows()
+        if not has_header:
+            # has_header is false, so first row is record, not header. save it to yield later
+            self.first_row = first_row
+
+    def iter_lines(self):
+        if self.first_row is not None:
+            if self.queue is None:
+                yield self.first_row
+                self.first_row = None
+            else:
+                self.queue.put(self.first_row)
+        
+        for row in self.file_iterator:
+            if self.queue is None:
+                yield row
+            else:
+                if self.queue.full():
+                    yield self.queue.get()
+                self.queue.put(row)
+
+    def _skip_header_rows(self, skip_header_row):
+        try:
+            for _ in range(skip_header_row):
+                line = next(self.file_iterator)
+                print(line)
+        except StopIteration:
+            #TODO improve err msg
+            raise Exception(f'No more data after skipping rows in header')
+
+    def _skip_empty_rows(self):
+        try:
+            first_row = next(self.file_iterator)
+            while first_row == b'':
+                first_row = next(self.file_iterator)
+        except StopIteration:
+            raise Exception(f'No more data other than empty rows')
+        return first_row

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -91,6 +91,7 @@ def get_sampled_schema_for_table(config, table_spec):
 
     samples = [sample for sample in sample_files(
         config, table_spec, s3_files_gen)]
+    LOGGER.info(f'sampled: {samples}')
 
     if skipped_files_count:
         LOGGER.warning(
@@ -269,9 +270,9 @@ def sample_file(table_spec, s3_path, file_handle, sample_rate, extension):
         return []
     if extension in ["csv", "txt"]:
         # If file object read from s3 bucket file else use extracted file object from zip or gz
-        preprocess_file_handle = preprocess.PreprocessStream(file_handle, table_spec)
-        fieldnames = preprocess_file_handle.get_headers(table_spec)
-        iterator = csv_iterator.get_row_iterator(preprocess_file_handle, fieldnames, table_spec)
+        preprocess_file_handle = preprocess.PreprocessStream(file_handle, table_spec, True)
+        fieldnames = preprocess_file_handle.header
+        iterator = csv_iterator.get_row_iterator(preprocess_file_handle, table_spec, fieldnames)
         csv_records = []
         if iterator:
             csv_records = get_records_for_csv(s3_path, sample_rate, iterator)

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -22,7 +22,8 @@ from singer_encodings import compression
 from tap_s3_csv import (
     utils,
     conversion,
-    csv_iterator
+    csv_iterator,
+    preprocess
 )
 
 LOGGER = singer.get_logger()
@@ -162,6 +163,9 @@ def get_records_for_csv(s3_path, sample_rate, iterator):
             yield row
 
         current_row += 1
+    if sampled_row_count == 0:
+        #TODO improve err msg
+        raise Exception(f'No rows sampled after skipping and ignoring rows')
 
     LOGGER.info("Sampled %s rows from %s", sampled_row_count, s3_path)
 
@@ -265,7 +269,9 @@ def sample_file(table_spec, s3_path, file_handle, sample_rate, extension):
         return []
     if extension in ["csv", "txt"]:
         # If file object read from s3 bucket file else use extracted file object from zip or gz
-        iterator = csv_iterator.get_row_iterator(file_handle, table_spec)
+        preprocess_file_handle = preprocess.PreprocessStream(file_handle, table_spec)
+        fieldnames = preprocess_file_handle.get_headers(table_spec)
+        iterator = csv_iterator.get_row_iterator(preprocess_file_handle, fieldnames, table_spec)
         csv_records = []
         if iterator:
             csv_records = get_records_for_csv(s3_path, sample_rate, iterator)
@@ -530,10 +536,10 @@ class GetFileRangeStream:
             raise ValueError(
                 f'start byte should be smaller than file size {file_size}')
 
-        # always return header first, after this each chunk iteration will discard first row but include partial row at the end
-        headers = self.__get_headers__()
-        LOGGER.info(f'headers: {headers}')
-        yield headers
+        # when iterating chunks to get rows, we always skip first row to consider the case where the row overlaps
+        # with previous chunk and handle it separately. First row on first chunk iss not handled so need to yield it
+        if self.start_byte == 0:
+            yield self.__get_first_row__()
 
         eol = self.__get_eol__()
 
@@ -632,7 +638,7 @@ class GetFileRangeStream:
         #LOGGER.info(f'total no of S3 calls: {count_s3_calls}')
 
     @retry_pattern()
-    def __get_headers__(self):
+    def __get_first_row__(self):
         iter_chunks = self.__get_object_iter_chunks__(
             iter_start_byte=0, iter_end_byte=self.chunk_size)
 

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -530,7 +530,7 @@ class GetFileRangeStream:
                 f'start byte should be smaller than file size {file_size}')
 
         # when iterating chunks to get rows, we always skip first row to consider the case where the row overlaps
-        # with previous chunk and handle it separately. First row on first chunk iss not handled so need to yield it
+        # with previous chunk and handle it separately. First row in first chunk is not handled so we need to yield it
         if self.start_byte == 0:
             yield self.__get_first_row__()
 

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -97,7 +97,11 @@ def get_sampled_schema_for_table(config, table_spec):
             "%s files got skipped during the last sampling.", skipped_files_count)
 
     if not samples:
-        raise Exception('File is empty.')
+        # Return empty properties for accept everything from data if no samples found
+        return {
+            'type': 'object',
+            'properties': {}
+        }, {}
 
     data_schema, date_format_map = conversion.generate_schema(
         samples, table_spec, config.get('string_max_length', False))

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -91,18 +91,13 @@ def get_sampled_schema_for_table(config, table_spec):
 
     samples = [sample for sample in sample_files(
         config, table_spec, s3_files_gen)]
-    LOGGER.info(f'sampled: {samples}')
 
     if skipped_files_count:
         LOGGER.warning(
             "%s files got skipped during the last sampling.", skipped_files_count)
 
     if not samples:
-        # Return empty properties for accept everything from data if no samples found
-        return {
-            'type': 'object',
-            'properties': {}
-        }
+        raise Exception('File is empty.')
 
     data_schema, date_format_map = conversion.generate_schema(
         samples, table_spec, config.get('string_max_length', False))
@@ -164,9 +159,6 @@ def get_records_for_csv(s3_path, sample_rate, iterator):
             yield row
 
         current_row += 1
-    if sampled_row_count == 0:
-        #TODO improve err msg
-        raise Exception(f'No rows sampled after skipping and ignoring rows')
 
     LOGGER.info("Sampled %s rows from %s", sampled_row_count, s3_path)
 

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -97,11 +97,7 @@ def get_sampled_schema_for_table(config, table_spec):
             "%s files got skipped during the last sampling.", skipped_files_count)
 
     if not samples:
-        # Return empty properties for accept everything from data if no samples found
-        return {
-            'type': 'object',
-            'properties': {}
-        }, {}
+        raise Exception('File is empty.')
 
     data_schema, date_format_map = conversion.generate_schema(
         samples, table_spec, config.get('string_max_length', False))

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -111,6 +111,10 @@ def handle_file(config, s3_path, table_spec, stream, extension, file_handler=Non
             file_handle = s3.get_csv_file(
                 config['bucket'], s3_path, start_byte, end_byte, range_size)
             LOGGER.info('using S3 Get Range method for csv import')
+            # csv.DictReader will parse the first non-empty row as header if fieldnames == None, else as the first record.
+            # For parallel threads, non-first threads will not be able to grab headers from the first part of the data,
+            # so we need to pass in fieldnames. First thread needs to handle first row in order to avoid having first row parsed
+            # as record when it's actually header. Set handle_first_row param for PreprocessStream to True for first thread.
             file_handle = preprocess.PreprocessStream(file_handle, table_spec, start_byte == 0)
             fieldnames = list(stream['schema']['properties'].keys())
         else:


### PR DESCRIPTION
WP-14838 data pre-process configuration: header/footer rows and column header [API] 
https://varicent.atlassian.net/browse/WP-14838

notes: 
- for handling first_row as header/first record, preprocessStream will skip empty lines to grab first row to follow csv.DictReader's behaviour.
- skip_header_row handled in first thread, skip_footer_row handled in last thread. With current implementation in symon backend, min split size is 5MB and ui added restriction of max 100 rows for skip header, footer.