### PR TITLE
WP-19954 support empty file refresh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-s3-csv"
-version = "1.4.22"
+version = "1.4.23"
 description = "Singer.io tap for extracting CSV files from S3"
 authors = ["Stitch"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -652,6 +652,12 @@ class GetFileRangeStream:
         for chunk in iter_chunks:
             if header_row == b'':
                 lines = (pending + chunk).splitlines(True)
+                
+                # for chunk with only headers(empty rows), the lines size is 1 and lines[:-1] will always be skipped
+                # need to handle this seperately
+                if len(lines) == 1:
+                    return lines[0].splitlines(False)[0]
+
                 for line in lines[:-1]:
                     return line.splitlines(False)[0]
                 pending = lines[-1]


### PR DESCRIPTION
JIRA: https://varicent.atlassian.net/browse/WP-19954

When the first time import has both columns and rows, the import process is fine.
Suppose the client updates the file and the new only has headers, the refresh would fail.

(No changes for the imports that need discovery, we still raise an empty file error for this.)

The reason why it fails:
We use `lines[:-1]` to avoid the last element of lines is a partial row). But for this case, we yield the `get_first_row` method when the start_byte is 0. And if the lines list only has the column names, the list size will be 1. So we will always be skipping the real headers. This is causing an issue later when we do `pre-process`.

We shouldn't have to worry about the partial row issue(don't think it will be a real use case that the entire chunk is for fieldnames)