### PR TITLE
WP-20960 fix discovery infer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-s3-csv"
-version = "1.8.0"
+version = "1.9.0"
 description = "Singer.io tap for extracting CSV files from S3"
 authors = ["Stitch"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]

--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -51,6 +51,10 @@ def infer_datetime(column, dateFormatMap):
     tmpCol = column.copy()
     # SalesForce exports empty dates as <NULL>
     tmpCol.replace('(?i)<null>', '', inplace=True, regex=True)
+    # if entire column is empty string, we want it to be inferred as string
+    tmpCol = tmpCol.replace('', np.nan).dropna()
+    if tmpCol.empty:
+        return False
     # pandas does not check the format properly
     return infer_datetime_and_format(tmpCol, dateFormatMap)
 

--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -32,7 +32,15 @@ def infer_column(column, dateFormatMap, lengths):
 
 def infer_number(column):
     tmpCol = column.copy()
-    tmpResult = pd.to_numeric(tmpCol, errors='ignore')
+    tmpCol = tmpCol.apply(lambda x: x.replace(',', ''))
+    # empty strings are converted to NaN, which is a valid number
+    # but if entire column is NaN, we want it to be inferred as string
+    try:
+        tmpResult = pd.to_numeric(tmpCol)
+        if tmpResult.dropna().empty:
+            return False
+    except Exception:
+        return False
 
     if tmpResult.dtype.name in ['float64', 'int64']:
         return True


### PR DESCRIPTION
- numbers with commas were inferred as string
- completely empty columns were inferred as numbers/dates, will be strings after fix
